### PR TITLE
Update start_wallet.sh

### DIFF
--- a/Wallet/start_wallet.sh
+++ b/Wallet/start_wallet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NODEOSBINDIR="/opt/XPRTestNet/bin/bin"
+NODEOSBINDIR="/usr/bin"
 DATADIR="/opt/XPRTestNet/Wallet"
 WALLET_HOST="127.0.0.1"
 WALLET_POSRT="3000"


### PR DESCRIPTION
Fix path for Keosd in the /{instalation_path}/XPRTestNet/Wallet that seems to be intalled in `/usr/bin`