### PR TITLE
Add ProtonNZ API endpoint and snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ https://protontest.eu.eosamsterdam.net
 https://api-xprnetwork-test.saltant.io
 https://testnet-api.xprdata.org
 https://testnet.rockerone.io
+https://tn1.protonnz.com
 ```
 
 # Backups
@@ -275,6 +276,7 @@ https://testnet.rockerone.io
   * [Snapshots / BP Cryptolions](https://backup.cryptolions.io/ProtonTestNet/snapshots/)
   * [Full State History Snapshots / BP Saltant](https://snapshots.saltant.io/testnet/)
   * [Snapshots & Full State History Snapshots / BP Bloxprod](https://snapshots.bloxprod.io/testnet/)
+  * [Snapshots / BP ProtonNZ](https://tn1.protonnz.com/snapshots/)
 
 
 


### PR DESCRIPTION
## Summary
- Added `https://tn1.protonnz.com` to the TESTNET API list
- Added ProtonNZ snapshots to the Backups section

## Snapshot Service Details
- **URL**: https://tn1.protonnz.com/snapshots/
- **Direct download**: https://tn1.protonnz.com/snapshots/latest-snapshot.bin
- **Update frequency**: Every 6 hours
- **Retention**: 1 week of snapshots

The snapshot page includes a browsable interface showing all available snapshots with dates, sizes, and download links.

## API Endpoint
- **URL**: https://tn1.protonnz.com
- **Chain info**: https://tn1.protonnz.com/v1/chain/get_info